### PR TITLE
Fix RegEx methods typo in code

### DIFF
--- a/5-regular-expressions/02-regexp-methods/article.md
+++ b/5-regular-expressions/02-regexp-methods/article.md
@@ -53,7 +53,7 @@ The array may have more than one element.
 For instance:
 
 ```js run
-lar str = "JavaScript is a programming language";
+let str = "JavaScript is a programming language";
 
 let result = str.match( *!*/JAVA(SCRIPT)/i*/!* );
 


### PR DESCRIPTION
It says `lar` instead of `let`, which makes `str` never declared.