### PR TITLE
Remove unnecessary quotation marks

### DIFF
--- a/1-js/02-first-steps/02-structure/article.md
+++ b/1-js/02-first-steps/02-structure/article.md
@@ -114,7 +114,7 @@ alert('Hello');
 alert('World'); // This comment follows the statement
 ```
 
-**Multiline comments start with a forward slash and an asterisk <code>"/&#42;"</code> and end with an asterisk and a forward slash <code>"&#42;/"</code>.**
+**Multiline comments start with a forward slash and an asterisk <code>/&#42;</code> and end with an asterisk and a forward slash <code>&#42;/</code>.**
 
 Like this:
 


### PR DESCRIPTION
When demonstrating how to start and end comments, there is a code block AND quotations, which can be confusing. Since the code block is already there, the quotation marks are redundant.