### PR TITLE
Fix code reference typo

### DIFF
--- a/1-js/02-first-steps/08-comparison/article.md
+++ b/1-js/02-first-steps/08-comparison/article.md
@@ -176,7 +176,7 @@ alert( null >= 0 ); // (3) *!*true*/!*
 
 Yeah, mathematically that's strange. The last result states that "`null` is equal or greater than zero". Then one of the comparisons above must be correct, but they are both falsy.
 
-The reason is that an equality check `==` and comparisons `> < >= <=` work differently. Comparisons convert `null` to a number, hence treat it as `0`. That's why (1) `null >= 0` is true and (3) `null > 0` is false.
+The reason is that an equality check `==` and comparisons `> < >= <=` work differently. Comparisons convert `null` to a number, hence treat it as `0`. That's why (3) `null >= 0` is true and (1) `null > 0` is false.
 
 From the other hand, the equality check `==` for `undefined` and `null` works by the rule, without any conversions. They equal each other and don't equal anything else. That's why (2) `null == 0` is false.
 


### PR DESCRIPTION
The code comments have (1) as null > 0, and (3) as null >= 0, but in the textual explanation, it was incorrectly stated as (3) null > 0, and (1) null >= 0.