### PR TITLE
syntax error corrected

### DIFF
--- a/1-js/04-object-basics/01-object/article.md
+++ b/1-js/04-object-basics/01-object/article.md
@@ -613,7 +613,7 @@ Also we can use the method [Object.assign](mdn:js/Object/assign) for that.
 The syntax is:
 
 ```js
-Object.assign(dest[, src1, src2, src3...])
+Object.assign(dest, [ src1, src2, src3...])
 ```
 
 - Arguments `dest`, and `src1, ..., srcN` (can be as many as needed) are objects.


### PR DESCRIPTION
there is a syntax error in the code after "Also we can use the method Object.assign for that." line.
The comma is added after the square bracket so which is wron. I have corrected in it.