### PR TITLE
Code typo in prompt example

### DIFF
--- a/1-js/02-first-steps/09-alert-prompt-confirm/article.md
+++ b/1-js/02-first-steps/09-alert-prompt-confirm/article.md
@@ -31,7 +31,7 @@ The mini-window with the message is called a *modal window*. The word "modal" me
 Function `prompt` accepts two arguments:
 
 ```js no-beautify
-result = prompt(title[, default]);
+result = prompt(title, [default]);
 ```
 
 It shows a modal window with a text message, an input field for the visitor and buttons OK/CANCEL.


### PR DESCRIPTION
It initially had (title[, default]), but I'm not sure why you had the array notation there since default is usually a string. I decided to leave it on there since I'm sure you had your reasons. However, I think it would be more appropriate without the array notation.