### PR TITLE
Fix undeclared variable

### DIFF
--- a/1-js/02-first-steps/07-operators/article.md
+++ b/1-js/02-first-steps/07-operators/article.md
@@ -409,7 +409,7 @@ For example:
 
 ```js run
 *!*
-a = (1+2, 3+4);
+let a = (1+2, 3+4);
 */!*
 
 alert( a ); // 7 (the result of 3+4)


### PR DESCRIPTION
Added `let` before `a` variable.
Alert shows this error `a is not defied`.