### PR TITLE
fix `HTML` typo with `innerHTML`

### DIFF
--- a/2-ui/1-document/05-basic-dom-node-properties/article.md
+++ b/2-ui/1-document/05-basic-dom-node-properties/article.md
@@ -258,7 +258,7 @@ Technically, these two lines do the same:
 elem.innerHTML += "...";
 // is a shorter way to write:
 *!*
-elem.innerHTML = elem.HTML + "..."
+elem.innerHTML = elem.innerHTML + "..."
 */!*
 ```
 


### PR DESCRIPTION
Corrects the ```innerHTML``` example.