### PR TITLE
Inner setTimeout() wrongly refering to tick()

### DIFF
--- a/1-js/06-advanced-functions/08-settimeout-setinterval/article.md
+++ b/1-js/06-advanced-functions/08-settimeout-setinterval/article.md
@@ -172,7 +172,7 @@ let timerId = setTimeout(function request() {
     delay *= 2;
   }
 
-  timerId = setTimeout(tick, delay);
+  timerId = setTimeout(request, delay);
 
 }, delay);
 ```


### PR DESCRIPTION
In the 'Recursive setTimeout' section in the example for sending server request the inner setTimeout() refers to a non-existing tick() function. Should be the outer request() function.