### PR TITLE
Typo

### DIFF
--- a/1-js/02-first-steps/07-operators/article.md
+++ b/1-js/02-first-steps/07-operators/article.md
@@ -145,7 +145,7 @@ An extract from the [precedence table](https://developer.mozilla.org/en/JavaScri
 | 3 | assignment | `=` |
 | ... | ... | ... |
 
-As we can see, the "unary plus" has a priority of `15`, higher than `13` for the "addition" (binary plus). That's why in the expression `"+apples + +oranges"` unary pluses work first, and then the addition.
+As we can see, the "unary plus" has a priority of `16`, higher than `13` for the "addition" (binary plus). That's why in the expression `"+apples + +oranges"` unary pluses work first, and then the addition.
 
 ## Assignment
 


### PR DESCRIPTION
Priority number of "unary plus" should be 16 according to the table. The number was typed 15, mistaken on line 148, the first line after the table.