### PR TITLE
Update 15-function-expressions-arrows

### DIFF
--- a/1-js/02-first-steps/15-function-expressions-arrows/article.md
+++ b/1-js/02-first-steps/15-function-expressions-arrows/article.md
@@ -450,7 +450,7 @@ Like this:
 let sum = (a, b) => {  // the figure bracket opens a multiline function
   let result = a + b;
 *!*
-  return result; // if we use figure brackets, must use return
+  return result; // if we use figure brackets, use return to get results
 */!*
 };
 


### PR DESCRIPTION
'Must' is very restrictive. The code would work without `return` directive, both in general or `"use strict";` modes.
For instance, we **must** declare variables, because code would break.