### PR TITLE
replace "progress" with "timeFraction" for clarity

### DIFF
--- a/3-animation/3-js-animation/article.md
+++ b/3-animation/3-js-animation/article.md
@@ -219,8 +219,8 @@ If we want to speed up the animation, we can use `progress` in the power `n`.
 For instance, a parabolic curve:
 
 ```js
-function quad(progress) {
-  return Math.pow(progress, 2)
+function quad(timeFraction) {
+  return Math.pow(timeFraction, 2)
 }
 ```
 


### PR DESCRIPTION
I guess you meant "timeFraction" and not "progress", as it is more consistent with the meaning you have been conveying before and later in this chapter, and despite having no impact on final result, i still think its worth fixing. As usual, thanks Ilya for this site!