### PR TITLE
Remove the redundant argument

### DIFF
--- a/2-ui/2-events/01-introduction-browser-events/article.md
+++ b/2-ui/2-events/01-introduction-browser-events/article.md
@@ -430,7 +430,7 @@ The method `handleEvent` does not have to do all the job by itself. It can call 
     handleEvent(event) {
       // mousedown -> onMousedown
       let method = 'on' + event.type[0].toUpperCase() + event.type.slice(1);
-      this[method](event);
+      this[method]();
     }
 
     onMousedown() {


### PR DESCRIPTION
This tutorial is awesome! I just think the argument of this[method] is redundant in this case. 