### PR TITLE
Clarify order of bubble/capture handlers on the target

### DIFF
--- a/2-ui/2-events/02-bubbling-and-capturing/article.md
+++ b/2-ui/2-events/02-bubbling-and-capturing/article.md
@@ -145,7 +145,7 @@ There are two possible values for that optional last argument:
 
 Note that while formally there are 3 phases, the 2nd phase ("target phase": the event reached the element) is not handled separately: handlers on both capturing and bubbling phases trigger at that phase.
 
-If one puts a handler on the target element -- it triggers last on the capturing state, and first on the bubbling stage.
+If one puts capturing and bubbling handlers on the target element, the capture handler triggers last in the capturing phase and the bubble handler triggers first in the bubbling phase.
 
 Let's see it in action:
 


### PR DESCRIPTION
The way the edited paragraph was written, I initially thought the bubble handler on the target would be ran before the capture handler, which seemed odd.  I believe this update clarifies the author's intention and describes better how the handlers actually work.