### PR TITLE
Fix: Wrong name for Firefox JavaScript engine

### DIFF
--- a/1-js/01-getting-started/1-intro/article.md
+++ b/1-js/01-getting-started/1-intro/article.md
@@ -25,7 +25,7 @@ The browser has an embedded engine, sometimes it's also called a "JavaScript vir
 Different engines have different "codenames", for example:
 
 - [V8](https://en.wikipedia.org/wiki/V8_(JavaScript_engine)) -- in Chrome and Opera.
-- [Gecko](https://en.wikipedia.org/wiki/Gecko_(software)) -- in Firefox.
+- [SpiderMonkey](https://en.wikipedia.org/wiki/SpiderMonkey) -- in Firefox.
 - ...There are other codenames like "Trident", "Chakra" for different versions of IE, "ChakraCore" for Microsoft Edge, "Nitro" and "SquirrelFish" for Safari etc.
 
 The terms above are good to remember, because they are used in developer articles on the internet. We'll use them too. For instance, if "a feature X is supported by V8", then it probably works in Chrome and Opera.


### PR DESCRIPTION
Gecko is the layout engine of Firefox. The JavaScript engine is called SpiderMonkey