### PR TITLE
miss closing parenthesis in arr.map() example, update article.md

### DIFF
--- a/1-js/05-data-types/05-array-methods/article.md
+++ b/1-js/05-data-types/05-array-methods/article.md
@@ -316,7 +316,7 @@ The syntax is:
 ```js
 let result = arr.map(function(item, index, array) {
   // returns the new value instead of item
-}
+})
 ```
 
 It calls the function for each element of the array and returns the array of results.


### PR DESCRIPTION
Typo - miss closing parenthesis in arr.map() example