### PR TITLE
Typo - miss ')'

### DIFF
--- a/1-js/05-data-types/05-array-methods/7-map-objects/solution.md
+++ b/1-js/05-data-types/05-array-methods/7-map-objects/solution.md
@@ -43,7 +43,7 @@ Here JavaScript would treat `{` as the start of function body, not the start of 
 let usersMapped = users.map(user => *!*({*/!*
   fullName: `${user.name} ${user.surname}`,
   id: user.id
-});
+}));
 ```
 
 Now fine.


### PR DESCRIPTION
Typo - miss ')' for closing parentheses of map method, line 46