### PR TITLE
Typo - expected ')'

### DIFF
--- a/1-js/05-data-types/05-array-methods/11-array-unique/solution.md
+++ b/1-js/05-data-types/05-array-methods/11-array-unique/solution.md
@@ -7,7 +7,7 @@ function unique(arr) {
   let result = [];
 
   for (let str of arr) {
-    if (!result.includes(str) {
+    if (!result.includes(str)) {
       result.push(str);
     }
   }


### PR DESCRIPTION
Typo - expected ')' for 'if' construction condition