### PR TITLE
1 > 02 > 12 > skipping parts (infinite loop)

### DIFF
--- a/1-js/02-first-steps/12-while-for/article.md
+++ b/1-js/02-first-steps/12-while-for/article.md
@@ -188,7 +188,7 @@ We can also remove the `step` part:
 let i = 0;
 
 for (; i < 3;) {
-  alert( i );
+  alert( i++ );
 }
 ```
 


### PR DESCRIPTION
There's an infinite loop on the second omit example, because i is never iterated. If you iterate inside the alert call, then that should fix it.