### PR TITLE
Fixed spy-decorator assignment test

### DIFF
--- a/1-js/06-advanced-functions/09-call-apply-decorators/01-spy-decorator/_js.view/test.js
+++ b/1-js/06-advanced-functions/09-call-apply-decorators/01-spy-decorator/_js.view/test.js
@@ -24,7 +24,7 @@ describe("spy", function() {
     let wrappedSum = spy(sum);
 
     assert.equal(wrappedSum(1, 2), 3);
-    assert(spy.calledWith(1, 2));
+    assert(sum.calledWith(1, 2));
   });
 
 
@@ -37,8 +37,8 @@ describe("spy", function() {
     calc.wrappedSum = spy(calc.sum);
 
     assert.equal(calculator.wrappedSum(1, 2), 3);
-    assert(spy.calledWith(1, 2));
-    assert(spy.calledOn(calculator));
+    assert(calc.sum.calledWith(1, 2));
+    assert(calc.sum.calledOn(calculator));
   });
 
 });


### PR DESCRIPTION
Hi!

We should be checking here original function not spy to ensure that we are wrapping transparently.

The test wasn't working and probably that was just a "typo" to begin with.

This makes it work properly.