### PR TITLE
Fix typo: 'pop to end' in Arrays:Stacks

### DIFF
--- a/1-js/05-data-types/04-array/article.md
+++ b/1-js/05-data-types/04-array/article.md
@@ -113,7 +113,7 @@ There's another use case for arrays -- the data structure named [stack](https://
 It supports two operations:
 
 - `push` adds an element to the end.
-- `pop` takes an element to the end.
+- `pop` takes an element from the end.
 
 So new elements are added or taken always from the "end".
 


### PR DESCRIPTION
Fixed small typo in decription of `array.pop()`.

> pop: takes **to** the end of the array

changed to

> pop: takes **from** the end of the array