### PR TITLE
labelled -> labeled

### DIFF
--- a/1-js/02-first-steps/04-variables/article.md
+++ b/1-js/02-first-steps/04-variables/article.md
@@ -99,7 +99,7 @@ There are subtle differences between `let` and `var`, but they do not matter for
 
 We can easily grasp the concept of a "variable" if we imagine it as a "box" for data, with a uniquely-named sticker on it.
 
-For instance, the variable `message` can be imagined as a box labelled `"message"` with the value `"Hello!"` in it:
+For instance, the variable `message` can be imagined as a box labeled `"message"` with the value `"Hello!"` in it:
 
 ![](variable.png)
 


### PR DESCRIPTION
Labeled and labelled are both correct spellings, and they mean the same thing. How you spell the word depends on your audience. If you are writing for American readers, labeled is the preferred spelling. In other places, such as Great Britain and Canada, labelled is a more common spelling than labeled.
(Taken from https://www.grammarly.com/blog/labeled-labelled)