### PR TITLE
fix typo in search algorithm exercise

### DIFF
--- a/1-js/07-object-oriented-programming/03-prototype-inheritance/2-search-algorithm/task.md
+++ b/1-js/07-object-oriented-programming/03-prototype-inheritance/2-search-algorithm/task.md
@@ -28,4 +28,4 @@ let pockets = {
 ```
 
 1. Use `__proto__` to assign prototypes in a way that any property lookup will follow the path: `pockets` -> `bed` -> `table` -> `head`. For instance, `pockets.pen` should be `3` (found in `table`), and `bed.glasses` should be `1` (found in `head`).
-2. Answer the question: is it faster to get `glasses` as `pocket.glasses` or `head.glasses`? Benchmark if needed.
+2. Answer the question: is it faster to get `glasses` as `pockets.glasses` or `head.glasses`? Benchmark if needed.


### PR DESCRIPTION
## Summary 

This PR fixes the following typo in the search algorithm exercise: the `pockets` object was incorrectly referred to as `pocket`.
