### PR TITLE
Update room.number to correspond to other usages

### DIFF
--- a/1-js/05-data-types/11-json/article.md
+++ b/1-js/05-data-types/11-json/article.md
@@ -131,7 +131,7 @@ let meetup = {
   title: "Conference",
 *!*
   room: {
-    number: 123,
+    number: 23,
     participants: ["john", "ann"]
   }
 */!*


### PR DESCRIPTION
It looks like the usage of `[Symbol("id")]: 123,` a couple lines above led to a mix-up, since `room.number` is set to 23 in the remainder of the file. 