### PR TITLE
MD typo in <!--BODY-->

### DIFF
--- a/2-ui/1-document/05-basic-dom-node-properties/3-tag-in-comment/solution.md
+++ b/2-ui/1-document/05-basic-dom-node-properties/3-tag-in-comment/solution.md
@@ -12,6 +12,6 @@ The answer: **`BODY`**.
 
 What's going on step by step:
 
-1. The content of `<body>` is replaced with the comment. The comment is <code>&lt;!--BODY--&gt;</code>, because `body.tagName == "BODY"`. As we remember, `tagName` is always uppercase in HTML.
+1. The content of `<body>` is replaced with the comment. The comment is `<!--BODY-->`, because `body.tagName == "BODY"`. As we remember, `tagName` is always uppercase in HTML.
 2. The comment is now the only child node, so we get it in `body.firstChild`.
 3. The `data` property of the comment is its contents (inside `<!--...-->`): `"BODY"`.


### PR DESCRIPTION
When displayed on https://javascript.info/basic-dom-node-properties there was a typo that said <!–BODY–> but it was supposed to say <!--BODY-->. It was caused by a markdown technicality.