### PR TITLE
Fixed small typo in "Styles and classes" page

### DIFF
--- a/2-ui/1-document/08-styles-and-classes/article.md
+++ b/2-ui/1-document/08-styles-and-classes/article.md
@@ -207,7 +207,7 @@ For instance, here `style` doesn't see the margin:
 </body>
 ```
 
-...But what if we need, say, increase the margin by 20px? We want the current value for the start.
+...But what if we need, say, to increase the margin by 20px? We want the current value for the start.
 
 There's another method for that: `getComputedStyle`.
 


### PR DESCRIPTION
A sentence on the page didn't make grammatical sense until I added the word "to".