### PR TITLE
Updated article about Object Methods

### DIFF
--- a/1-js/04-object-basics/04-object-methods/article.md
+++ b/1-js/04-object-basics/04-object-methods/article.md
@@ -316,7 +316,7 @@ When parentheses `()` are called on the Reference Type, they receive the full in
 
 Any other operation like assignment `hi = user.hi` discards the reference type as a whole, takes the value of `user.hi` (a function) and passes it on. So any further operation "loses" `this`.
 
-So, as the result, the value of `this` is only passed the right way if the function is called directly using a dot `obj.method()` or square brackets `obj[method]()` syntax (they do the same here).
+So, as the result, the value of `this` is only passed the right way if the function is called directly using a dot `obj.method()` or square brackets `obj[method]()` syntax (they do the same here). Later in this tutorial, we will learn various ways to solve this problem such as [func.bind()](https://javascript.info/bind#solution-2-bind).
 
 ## Arrow functions have no "this"
 


### PR DESCRIPTION
When I came across part of the code examples on https://javascript.info/object-methods#internals-reference-type that said that the code line (user.name == "John" ? user.hi : user.bye)(); didn't work, it bugged me that I couldn't figure out what code changes I would need to make to make it work. The article just explained why it didn't work, but offered no hint as to how to make it work. I therefore wasted time trying to figure it out. After I gave up and continued with the tutorial, I figured out that a solution was written over 20 pages later on https://javascript.info/bind#solution-2-bind . I offer this change so that others won't waste time the same way I did.