### PR TITLE
Insert missing array index in solution

### DIFF
--- a/2-ui/1-document/04-searching-elements-dom/1-find-elements/solution.md
+++ b/2-ui/1-document/04-searching-elements-dom/1-find-elements/solution.md
@@ -25,7 +25,7 @@ let form = document.getElementsByName('search')[0]
 document.querySelector('form[name="search"]')
 
 // 5. The first input in that form.
-form.getElementsByTagName('input')
+form.getElementsByTagName('input')[0]
 // or
 form.querySelector('input')
 


### PR DESCRIPTION
Following the tutorial in Firefox 56, I got an `HTMLCollection` from `form.getElementsByTagName('input')` but `form.getElementsByTagName('input')[0]` appears to return the first input correctly.