### PR TITLE
Don't need arrow function here

### DIFF
--- a/6-async/05-async-await/article.md
+++ b/6-async/05-async-await/article.md
@@ -144,7 +144,7 @@ class Thenable {
   then(resolve, reject) {
     alert(resolve); // function() { native code }
     // resolve with this.num*2 after 1000ms
-    setTimeout(() => resolve(this.num * 2), 1000); // (*)
+    setTimeout(resolve, 1000, this.num * 2); // (*)
   }
 };
 


### PR DESCRIPTION
The signature of `setTimeout` is:
```js
setTimeout(function[, delay, param1, param2, ...]);
```
https://devdocs.io/dom/windoworworkerglobalscope/settimeout