### PR TITLE
Fixed typo

### DIFF
--- a/2-ui/2-events/02-bubbling-and-capturing/article.md
+++ b/2-ui/2-events/02-bubbling-and-capturing/article.md
@@ -10,7 +10,7 @@ This handler is assigned to `<div>`, but also runs if you click any nested tag l
 </div>
 ```
 
-Isn't it a bit strange? Why the handler on `<div>` runs if the actual click was on `<em>`?
+Isn't it a bit strange? Why does the handler on `<div>` run if the actual click was on `<em>`?
 
 ## Bubbling
 
@@ -18,7 +18,7 @@ The bubbling principle is simple.
 
 **When an event happens on an element, it first runs the handlers on it, then on its parent, then all the way up on other ancestors.**
 
-Let's say, we have 3 nested elements `FORM > DIV > P` with a handler on each of them:
+Let's say we have 3 nested elements `FORM > DIV > P` with a handler on each of them:
 
 ```html run autorun
 <style>


### PR DESCRIPTION
Fixed a grammatical error at the top of the article.

Instead of 'why the handler on <div> runs', it should say 'why _does_ the handler on <div> run'.