### PR TITLE
Fix Arrow functions note syntax typo

### DIFF
--- a/1-js/06-advanced-functions/02-rest-parameters-spread-operator/article.md
+++ b/1-js/06-advanced-functions/02-rest-parameters-spread-operator/article.md
@@ -119,6 +119,8 @@ function f() {
 
 f(1); // 1
 ```
+````
+
 As we remember, arrow functions don't have their own `this`. Now we know they don't have the special `arguments` object either.
 
 ## Spread operator [#spread-operator]


### PR DESCRIPTION
Missing end quotes make Spread operator section render into the note.

<img width="861" alt="screen shot 2018-09-17 at 12 21 54" src="https://user-images.githubusercontent.com/14107029/45615133-5469e980-ba74-11e8-915f-05bfd84c5cc1.png">
