### PR TITLE
Updated 'Non-english' to 'Non-English' in 04-variables/article.md

### DIFF
--- a/1-js/02-first-steps/04-variables/article.md
+++ b/1-js/02-first-steps/04-variables/article.md
@@ -183,7 +183,7 @@ let my-name; // a hyphen '-' is not allowed in the name
 Variables named `apple` and `AppLE` -- are two different variables.
 ```
 
-````smart header="Non-english letters are allowed, but not recommended"
+````smart header="Non-English letters are allowed, but not recommended"
 It is possible to use any language, including cyrillic letters or even hieroglyphs, like this:
 
 ```js


### PR DESCRIPTION
Keeps consistency with the rest of the document which uses the capitalised proper noun 'English'.