### PR TITLE
4-mouse-drag-2-drag-heroes - Fixed multiple issues that occur when mouseup is dispatched outside window

### DIFF
--- a/2-ui/3-event-details/4-mouse-drag-and-drop/2-drag-heroes/solution.view/soccer.js
+++ b/2-ui/3-event-details/4-mouse-drag-and-drop/2-drag-heroes/solution.view/soccer.js
@@ -1,3 +1,5 @@
+let isDragging = false;
+
 document.addEventListener('mousedown', function(event) {
 
   let dragElement = event.target.closest('.draggable');
@@ -5,16 +7,19 @@ document.addEventListener('mousedown', function(event) {
   if (!dragElement) return;
 
   event.preventDefault();
-  let coords, shiftX, shiftY;
-
-  startDrag(event.clientX, event.clientY);
-
-  document.addEventListener('mousemove', onMouseMove);
-
-  dragElement.onmouseup = function() {
-    finishDrag();
+  
+  dragElement.ondragstart = function() {
+      return false;
   };
 
+  let coords, shiftX, shiftY;
+
+  startDrag(dragElement, event.clientX, event.clientY);
+
+  function onMouseUp(event) {
+    finishDrag();
+  };
+  
   function onMouseMove(event) {
     moveAt(event.clientX, event.clientY);
   }
@@ -22,25 +27,37 @@ document.addEventListener('mousedown', function(event) {
   // on drag start:
   //   remember the initial shift
   //   move the element position:fixed and a direct child of body
-  function startDrag(clientX, clientY) {
+  function startDrag(element, clientX, clientY) {
+    if(isDragging) {
+      return;
+    }
+    
+    isDragging = true;
+    
+    document.addEventListener('mousemove', onMouseMove);
+    element.addEventListener('mouseup', onMouseUp);
 
-    shiftX = clientX - dragElement.getBoundingClientRect().left;
-    shiftY = clientY - dragElement.getBoundingClientRect().top;
+    shiftX = clientX - element.getBoundingClientRect().left;
+    shiftY = clientY - element.getBoundingClientRect().top;
 
-    dragElement.style.position = 'fixed';
-
-    document.body.append(dragElement);
+    element.style.position = 'fixed';
 
     moveAt(clientX, clientY);
   };
 
   // switch to absolute coordinates at the end, to fix the element in the document
   function finishDrag() {
+    if(!isDragging) {
+      return;
+    }
+    
+    isDragging = false;
+
     dragElement.style.top = parseInt(dragElement.style.top) + pageYOffset + 'px';
     dragElement.style.position = 'absolute';
 
     document.removeEventListener('mousemove', onMouseMove);
-    dragElement.onmouseup = null;
+    dragElement.removeEventListener('mouseup', onMouseUp);
   }
 
   function moveAt(clientX, clientY) {


### PR DESCRIPTION
This fixes 2 issues that occurred in the previous version. 

Issue 1: Use latest versions of Chrome or Firefox on Windows 10. Mousedown on draggable hero. Move mouse out of window/frame. Mouseup. Move mouse back into window/frame. Hero continues following mouse. Click. Hero still follows mouse. This is fixed by replacing .onmouseup with add/removeEventListener. Hero now stops dragging after the click. 

Issue 2: After issue 1 is fixed, hero "jumps" after mouse is moved back into window/frame and mouse is clicked. This is because multiple mouseup events are dispatched and position is adjusted twice for Y offset. Tracking dragging status with a new isDragging variable prevents this. 

