### PR TITLE
Fix return

### DIFF
--- a/5-regular-expressions/09-regexp-groups/5-parse-expression/solution.md
+++ b/5-regular-expressions/09-regexp-groups/5-parse-expression/solution.md
@@ -41,7 +41,7 @@ function parse(expr) {
 
   let result = expr.match(reg);
 
-  if (!result) return;
+  if (!result) return [];
   result.shift();
 
   return result;


### PR DESCRIPTION
return may need to be an empty array, else if you:
parse(""), it will raise TypeError