### PR TITLE
[update] remove word, "novice"

### DIFF
--- a/4-frames-and-windows/03-cross-window-communication/article.md
+++ b/4-frames-and-windows/03-cross-window-communication/article.md
@@ -134,7 +134,7 @@ Here, look:
 </script>
 ```
 
-That's actually a well-known pitfall for novice developers. We shouldn't work with the document immediately, because that's the *wrong document*. If we set any event handlers on it, they will be ignored.
+That's actually a well-known pitfall for developers. We shouldn't work with the document immediately, because that's the *wrong document*. If we set any event handlers on it, they will be ignored.
 
 ...But the `onload` event triggers when the whole iframe with all resources is loaded. What if we want to act sooner, on `DOMContentLoaded` of the embedded document?
 


### PR DESCRIPTION
The word "novice" is unneeded within a sentence describing a common pitfall.

----

Thank you so much for this work (repository). I am a regular reader. 🙏 