### PR TITLE
Delete redundant Array.from() call

### DIFF
--- a/1-js/05-data-types/07-map-set-weakmap-weakset/02-filter-anagrams/solution.md
+++ b/1-js/05-data-types/07-map-set-weakmap-weakset/02-filter-anagrams/solution.md
@@ -68,7 +68,7 @@ function aclean(arr) {
     obj[sorted] = arr[i];
   }
 
-  return Array.from(Object.values(obj));
+  return Object.values(obj);
 }
 
 let arr = ["nap", "teachers", "cheaters", "PAN", "ear", "era", "hectares"];


### PR DESCRIPTION
Since Object.values(obj) returns an array it's an overkill to make additional Array.from() call on it.
PS.
BTW I've used similar but a little bit different approach to solve it on my own before checking answers
```js
function aclean(arr) {
  const s = new Set();
  return arr.reduce((r,v,i) => {
    v = v.toLowerCase().split('').sort().join('');
    return s.has(v) ? r : (s.add(v), [...r, arr[i]]);
  }, []); 
}
```