### PR TITLE
typo

### DIFF
--- a/1-js/07-object-oriented-programming/04-function-prototype/article.md
+++ b/1-js/07-object-oriented-programming/04-function-prototype/article.md
@@ -139,7 +139,7 @@ Rabbit.prototype.jumps = true
 // the default Rabbit.prototype.constructor is preserved
 ```
 
-Or, alternatively, recreate the `constructor` property it manually:
+Or, alternatively, recreate the `constructor` property manually:
 
 ```js
 Rabbit.prototype = {


### PR DESCRIPTION
Or, alternatively, recreate the constructor property it manually: -> Or, alternatively, recreate the constructor property manually: