### PR TITLE
fix the variable declaration mistake

### DIFF
--- a/2-ui/1-document/07-modifying-document/7-create-object-tree/innerhtml.view/index.html
+++ b/2-ui/1-document/07-modifying-document/7-create-object-tree/innerhtml.view/index.html
@@ -29,11 +29,12 @@
 
     function createTreeText(obj) { // standalone recursive function
       let li = '';
+      let ul;
       for (let key in obj) {
         li += '<li>' + key + createTreeText(obj[key]) + '</li>';
       }
       if (li) {
-        let ul = '<ul>' + li + '</ul>'
+        ul = '<ul>' + li + '</ul>'
       }
       return ul || '';
     }


### PR DESCRIPTION
The code doesn't work since ul is unreachable here due to let declaration
```js
function createTreeText(obj) { // standalone recursive function
      let li = '';
      for (let key in obj) {
        li += '<li>' + key + createTreeText(obj[key]) + '</li>';
      }
      if (li) {
        let ul = '<ul>' + li + '</ul>'
      }
      return ul || '';
    }
```
First variant:
```js
function createTreeText(obj) { // standalone recursive function
      let li = '';
      let ul;
      for (let key in obj) {
        li += '<li>' + key + createTreeText(obj[key]) + '</li>';
      }
      if (li) {
        ul = '<ul>' + li + '</ul>'
      }
      return ul || '';
    }
```
another way is to use 'old' var declaration
```js
function createTreeText(obj) { // standalone recursive function
      let li = '';
      for (let key in obj) {
        li += '<li>' + key + createTreeText(obj[key]) + '</li>';
      }
      if (li) {
        var ul = '<ul>' + li + '</ul>'
      }
      return ul || '';
    }
```
In my PR I proposed the first one since it's kinda trendy and modern
I've enjoyed to solving the task, btw there are my solutions if they are looking more appealing they can be grabbed alternatively.
 [innerHTML](https://raw.githubusercontent.com/dagolinuxoid/fccActivityLog/master/2101019/viaInnerHTMLscript.js)
[domMethods](https://raw.githubusercontent.com/dagolinuxoid/fccActivityLog/master/2101019/script.js)