### PR TITLE
typo "brackets" to "parentheses"

### DIFF
--- a/1-js/05-data-types/09-destructuring-assignment/article.md
+++ b/1-js/05-data-types/09-destructuring-assignment/article.md
@@ -335,7 +335,7 @@ The problem is that JavaScript treats `{...}` in the main code flow (not inside 
 }
 ```
 
-To show JavaScript that it's not a code block, we can wrap the whole assignment in brackets `(...)`:
+To show JavaScript that it's not a code block, we can wrap the whole assignment in parentheses `(...)`:
 
 ```js run
 let title, width, height;


### PR DESCRIPTION
change word to describe syntax example accordingly