### PR TITLE
change "brackets" to "parentheses"

### DIFF
--- a/1-js/06-advanced-functions/03-closure/4-closure-sum/solution.md
+++ b/1-js/06-advanced-functions/03-closure/4-closure-sum/solution.md
@@ -1,4 +1,4 @@
-For the second brackets to work, the first ones must return a function.
+For the second parentheses to work, the first ones must return a function.
 
 Like this:
 

--- a/1-js/06-advanced-functions/03-closure/4-closure-sum/task.md
+++ b/1-js/06-advanced-functions/03-closure/4-closure-sum/task.md
@@ -6,7 +6,7 @@ importance: 4
 
 Write function `sum` that works like this: `sum(a)(b) = a+b`.
 
-Yes, exactly this way, via double brackets (not a mistype).
+Yes, exactly this way, using double parentheses (not a mistype).
 
 For instance:
 


### PR DESCRIPTION
Changed on the task and solution.

Note: I did a little research on this to because I was curious and apparently using the word "parentheses" really most common in American English which I did not know. As a native English speaker I've always just called them parentheses by default..  But it seems that in many countries they are referred to as "Round Brackets". 

Considering this is the English version of the site and most everyone here calls them parentheses.. I think this is the convention you are wanting... Also of note, "Parenthesis" is essentially describing a singular parentheses "(" or ")" or also can be used to describe the "state" of something being parenthesized.. 

> It also needs to be pointed out that US English uses the term parentheses to mean the brackets (…) themselves (specifically the round ones), rather than their content. The word brackets is generally reserved for square […] and curly {…} versions

https://proofwiki.org/wiki/Definition:Parenthesis
