### PR TITLE
"use strict" directive is missing in code example

### DIFF
--- a/1-js/04-object-basics/04-object-methods/article.md
+++ b/1-js/04-object-basics/04-object-methods/article.md
@@ -205,6 +205,7 @@ admin['f'](); // Admin (dot or square brackets access the method – doesn't mat
 Actually, we can call the function without an object at all:
 
 ```js run
+'use strict';
 function sayHi() {
   alert(this);
 }


### PR DESCRIPTION
but it's supposed to be there, according description below the code.