### PR TITLE
typo + add link to relevant chapter

### DIFF
--- a/1-js/07-object-oriented-programming/06-prototype-methods/2-dictionary-tostring/solution.md
+++ b/1-js/07-object-oriented-programming/06-prototype-methods/2-dictionary-tostring/solution.md
@@ -1,7 +1,7 @@
 
 The method can take all enumerable keys using `Object.keys` and output their list.
 
-To make `toString` non-enumerable, let's define it using a property descriptor. The syntax of `Object.create` allows to provide an object with property descriptors as the second argument.
+To make `toString` non-enumerable, let's define it using a property descriptor. The syntax of `Object.create` allows us to provide an object with property descriptors as the second argument.
 
 ```js run
 *!*
@@ -27,3 +27,5 @@ alert(dictionary); // "apple,__proto__"
 ```
 
 When we create a property using a descriptor, its flags are `false` by default. So in the code above, `dictionary.toString` is non-enumerable.
+
+See the the chapter on [Property flags and descriptors](http://javascript.info/property-descriptors) for review.


### PR DESCRIPTION
Fixed typo and added back link at end to http://javascript.info/property-descriptors for convenience because I forgot this part:

> If the property exists, defineProperty updates its flags. Otherwise, it creates the property with the given value and flags; in that case, if a flag is not supplied, it is assumed false.

