### PR TITLE
add task/solution to "Extended Clock"

### DIFF
--- a/1-js/07-object-oriented-programming/10-class-inheritance/2-clock-class-extended/solution.md
+++ b/1-js/07-object-oriented-programming/10-class-inheritance/2-clock-class-extended/solution.md
@@ -1,0 +1,24 @@
+```js run
+// extended-clock.js
+
+class ExtendedClock extends Clock {
+  constructor(options) {
+    super(options);
+    let { precision=1000 } = options;
+    this._precision = precision;
+  }
+
+  start() {
+    this._render();
+    this._timer = setInterval(() => this._render(), this._precision);
+  }
+}
+
+let lowResolutionClock = new ExtendedClock({
+  template: 'h:m:s',
+  precision: 10000,
+});
+
+lowResolutionClock.start();
+
+```

--- a/1-js/07-object-oriented-programming/10-class-inheritance/2-clock-class-extended/task.md
+++ b/1-js/07-object-oriented-programming/10-class-inheritance/2-clock-class-extended/task.md
@@ -4,9 +4,55 @@ importance: 5
 
 # Extended clock
 
-We've got a `Clock` class. As of now, it prints the time every second.
+We've got a `Clock` class. As of now, it prints the time every second:
 
+```js run
+// clock.js
+
+class Clock {
+  constructor({ template }) {
+    this._template = template;
+  }
+
+  _render() {
+    let date = new Date();
+
+    let hours = date.getHours();
+    if (hours < 10) hours = '0' + hours;
+
+    let mins = date.getMinutes();
+    if (mins < 10) mins = '0' + mins;
+
+    let secs = date.getSeconds();
+    if (secs < 10) secs = '0' + secs;
+
+    let output = this._template
+      .replace('h', hours)
+      .replace('m', mins)
+      .replace('s', secs);
+
+    console.log(output);
+  }
+
+  stop() {
+    clearInterval(this._timer);
+  }
+
+  start() {
+    this._render();
+    this._timer = setInterval(() => this._render(), 1000);
+  }
+}
+
+let clock = new Clock({
+  template: 'h:m:s',
+});
+
+clock.start();
+
+```
 Create a new class `ExtendedClock` that inherits from `Clock` and adds the parameter `precision` -- the number of `ms` between "ticks". Should be `1000` (1 second) by default.
 
 - Your code should be in the file `extended-clock.js`
 - Don't modify the original `clock.js`. Extend it.
+


### PR DESCRIPTION
Added the code from sandbox files here. While I tested this was also wondering about this statement:

> Create a new class ExtendedClock that inherits from Clock and adds the parameter precision -- the number of ms between "ticks". Should be 1000 (1 second) by default.

Should this be changed to 10000? 

In the solution / sandbox it is set to 10000 at least (and shows every ten seconds accordingly):

```
let lowResolutionClock = new ExtendedClock({
      template: 'h:m:s',
      precision: 10000
    });

```

https://next.plnkr.co/edit/ArMtHx1QBohRahJxlOJz?p=preview