### PR TITLE
Incorrect way of dealing with imprecise calculations

### DIFF
--- a/1-js/05-data-types/02-number/article.md
+++ b/1-js/05-data-types/02-number/article.md
@@ -246,15 +246,7 @@ Can we work around the problem? Sure, there're a number of ways:
     alert( +sum.toFixed(2) ); // 0.3
     ```
 
-2. We can temporarily turn numbers into integers for the maths and then revert it back. It works like this:
-
-    ```js run
-    alert( (0.1 * 10 + 0.2 * 10) / 10 ); // 0.3
-    ```
-
-    This works because when we do `0.1 * 10 = 1` and `0.2 * 10 = 2` then both numbers become integers, and there's no precision loss. 
-
-3. If we were dealing with a shop, then the most radical solution would be to store all prices in cents and use no fractions at all. But what if we apply a discount of 30%? In practice, totally evading fractions is rarely feasible, so the solutions above help avoid this pitfall.
+2. If we were dealing with a shop, then the most radical solution would be to store all prices in cents and use no fractions at all. But what if we apply a discount of 30%? In practice, totally evading fractions is rarely feasible, so the solutions above help avoid this pitfall.
 
 ````smart header="The funny thing"
 Try running this:


### PR DESCRIPTION
I think one of the methods recommended in **Imprecise calculations** section is incorrect.
For example
```
( (0.28*100) + (0.14*100) ) / 100 === 0.42 // false
```