### PR TITLE
Update solution.md

### DIFF
--- a/1-js/06-advanced-functions/10-bind/2-write-to-object-after-bind/solution.md
+++ b/1-js/06-advanced-functions/10-bind/2-write-to-object-after-bind/solution.md
@@ -16,3 +16,21 @@ user.g();
 The context of a bound function is hard-fixed. There's just no way to further change it.
 
 So even while we run `user.g()`, the original function is called with `this=null`.
+
+PS: if you try it on Chrome or other devTool that is not using `'strict mode'`, `this` will reference the `window` object. Just for test purposes, try a IIFE on `'strict mode'`:
+
+```js run
+  (function() {
+
+      'use strict'
+      function f() {
+        alert( this ); // null
+      }
+
+      let user = {
+        g: f.bind(null)
+      };
+
+      user.g();
+  }());
+  ```


### PR DESCRIPTION
Hi Ilya! I proposed this because there's a lot of people studying the tutorial and testing with Chrome Console and the result is not `null` but `[object window]`; also because it was the proposed tool for start the tutorial.

Could be useful (if you did not that in another further place), to explain the specifics of `'strict mode'` and `f.bind(context)` maybe?