### PR TITLE
Added missing semicolon

### DIFF
--- a/1-js/02-first-steps/13-switch/article.md
+++ b/1-js/02-first-steps/13-switch/article.md
@@ -163,7 +163,7 @@ switch (arg) {
     alert( 'Never executes!' );
     break;
   default:
-    alert( 'An unknown value' )
+    alert( 'An unknown value' );
 }
 ```
 


### PR DESCRIPTION
http://javascript.info/switch#type-matters 

I was reading this and noticed that a semicolon is missing so I went ahead and added it. 