### PR TITLE
Update 07-modifying-document

### DIFF
--- a/2-ui/1-document/07-modifying-document/article.md
+++ b/2-ui/1-document/07-modifying-document/article.md
@@ -290,7 +290,7 @@ So here's an alternative variant of showing a message:
   background-color: #dff0d8;
 }
 </style>
-
+<div></div>
 <script>
   document.body.insertAdjacentHTML("afterbegin", `<div class="alert alert-success">
     <strong>Hi there!</strong> You've read an important message.


### PR DESCRIPTION
Fix empty plunkr viewbox window

Plunkr preview will be empty if there is no `<div></div>` (or other element besides `<script/>` or `<style/>`). I guess this fix can be applied to all plunkrs code snippets in this repo.